### PR TITLE
Use device selection in predict

### DIFF
--- a/src/algorithms/couta_algo.py
+++ b/src/algorithms/couta_algo.py
@@ -304,7 +304,7 @@ class COUTA:
         self.net.eval()
         with torch.no_grad():
             for x in dataloader:
-                x = x.float().to('cuda')
+                x = x.float().to(self.device)
                 x_output = self.net(x)
                 representation_lst.append(x_output[0])
                 if self.umc:


### PR DESCRIPTION
I noticed that the parameter 'device': 'cpu' didn't apply to the predict method.